### PR TITLE
Send email to admins in case of error.

### DIFF
--- a/robocjk/logging.py
+++ b/robocjk/logging.py
@@ -1,0 +1,32 @@
+import logging
+import traceback
+
+
+class ThrottleFilter(logging.Filter):
+    def __init__(self, timeout=3600):
+        super().__init__()
+        self.timeout = timeout
+
+    def filter(self, record):
+        try:
+            from django.core.cache import caches
+
+            cache = caches["logging"]
+            if record.exc_info:
+                exc_type = record.exc_info[0]
+                exc_value = record.exc_info[1]
+                exc_traceback = exc_value.__traceback__
+                lastframe = traceback.extract_tb(exc_traceback)[-1]
+                key = (
+                    "logging.ThrottleFilter "
+                    f"{exc_type.__name__} "
+                    f"{lastframe.filename} "
+                    f"{lastframe.lineno} "
+                    f"{lastframe.name}"
+                )
+                if cache.get(key):
+                    return False
+                cache.set(key, True, self.timeout)
+        except Exception:
+            pass
+        return True

--- a/robocjk/tests/test_logging.py
+++ b/robocjk/tests/test_logging.py
@@ -1,0 +1,22 @@
+import logging
+
+from django.core import mail
+from django.test import TestCase
+
+logger = logging.getLogger(__name__)
+
+
+class LoggingTestCase(TestCase):
+    def test_error_mail_admins(self):
+        logger.error("Test error mail admin handler.")
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(
+            mail.outbox[-1].subject,
+            "[development] ERROR: Test error mail admin handler.",
+        )
+        logger.error("Test another error mail admin handler.")
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(
+            mail.outbox[-1].subject,
+            "[development] ERROR: Test another error mail admin handler.",
+        )


### PR DESCRIPTION
This PR fixes #85 and more specifically does this:

- Configure the server with the necessary options for sending emails
- Send the emails to the admins in case of errors (both unhandled exceptions and error logs)
- Add a new `ThrottleFilter` logging filter to avoid sending multiple emails for the same error in a short period of time (currently set to 1 hour)
